### PR TITLE
Add jupyterquiz fehlte in der requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 jupyter-book
 matplotlib
 numpy
+jupyterquiz


### PR DESCRIPTION
Damit `jb build .` jetzt jupyterquiz mit nutzt muss einmal lokal im virtuellen Environment `pip install -r requirements.txt` neu ausgeführt werden.